### PR TITLE
Change role attribution

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -66,8 +66,11 @@ gift_strings = [
   "🎁 {0} just sent a 🏆 Trophy to {1}. This is when you celebrate your moment of victory, if you had one!"
 ]
 [reward_roles]
-# Roles given to users once they reach a certain coin threshold
-70 = 778778734500380722
+# Roles given to users once they reach a certain gift sent and gift receive threshold
+# The role is given only if both thresholds are met
+roles_list = [
+  {nbSent = 70, nbReceived = 30, roleId = 778778734500380722}
+]
 
 [database]
 # The keyword arguments that get passed into database connectors.


### PR DESCRIPTION
Added the gift_received threshold check in the add_score function.
The reward_roles part of the config.toml has been updated to allow the use of the nbSent and nbReceived thresholds for each role.